### PR TITLE
#30: Add 'move' and 'mv' aliases to 'rename' cmd and divers help output updates

### DIFF
--- a/cmd/code.go
+++ b/cmd/code.go
@@ -10,7 +10,7 @@ import (
 // codeCmd represents the code command
 var codeCmd = &cobra.Command{
 	Use:   "code",
-	Short: "Open space as a workspace in Visual Studio Code",
+	Short: "Open Space as a workspace in Visual Studio Code",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		space, err := gitspaces.GetSpace()

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/davfive/gitspaces/v2/console"
 	"github.com/davfive/gitspaces/v2/gitspaces"
 	"github.com/davfive/gitspaces/v2/helper"
@@ -12,18 +10,16 @@ import (
 
 // createCmd represents the create command
 var createCmd = &cobra.Command{
-	Use:   "create [flags] URL [DIR]",
-	Short: "Creates a GitSpace from the provided repo url",
-	Long:  "Creates a GitSpace from the provided repo url.",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return fmt.Errorf("requires a URL argument")
-		}
-		if len(args) > 2 {
-			return fmt.Errorf("unexpected positional arguments after URL [DIR]")
-		}
-		return nil
-	},
+	Use: UseWhere(
+		"create [flags] <repo> [... <repo-N>] [<dir>]",
+		[]WhereArg{
+			{"repo", "repo as in `git clone <repo>`"},
+			{"dir", "Directory to use for GitSpaces project. Default is first repo name."},
+		},
+	),
+	Short:   "Creates a GitSpace from the provided repo url",
+	Args:    cobra.MinimumNArgs(1),
+	Aliases: []string{"c"},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		url := args[0]
 		dir := helper.GetStringAtIndex(args, 1, "")

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -12,16 +12,22 @@ import (
 
 // renameCmd represents the rename command
 var renameCmd = &cobra.Command{
-	Use:   "rename",
-	Short: "Rename the current space",
-	Long:  `Rename the current space`,
+	Use: UseWhere(
+		"rename [flags] [<new-name>]",
+		[]WhereArg{
+			{"new-name", "name of the new space"},
+		},
+	),
+	Short:   "Rename the current space",
+	Args:    cobra.RangeArgs(0, 1),
+	Aliases: []string{"move", "mv"},
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		space, err := gitspaces.GetSpace()
 		if err != nil {
 			return err
 		}
 
-		if err = space.Rename(); err != nil {
+		if err = space.Rename(args...); err != nil {
 			return console.Errorln("Failed to rename space: %s", err)
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,7 +11,6 @@ import (
 var rootCmd = &cobra.Command{
 	Use:     "gitspaces",
 	Short:   "Concurrent development manager for a single project",
-	Long:    "Concurrent development manager for a single project",
 	Version: helper.GetBuildVersion(),
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return gitspaces.Init(cmd)

--- a/cmd/sleep.go
+++ b/cmd/sleep.go
@@ -13,13 +13,8 @@ import (
 // sleepCmd represents the sleep command
 var sleepCmd = &cobra.Command{
 	Use:   "sleep",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
+	Short: "Put this Space to sleep. Invites user to Wakeup a new Space.",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		space, err := gitspaces.GetSpace()
 		if err != nil {

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -13,6 +13,7 @@ import (
 var switchCmd = &cobra.Command{
 	Use:   "switch",
 	Short: "Switch to project/space (user choice)",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		space, err := gitspaces.SwitchSpace()
 		if err != nil {

--- a/cmd/usewhere.go
+++ b/cmd/usewhere.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"slices"
+)
+
+func UseWhere(use string, whereArgs []WhereArg) string {
+	// cmd.Command.Use expects a string (why I can't use UseWhereStruct as Stringer)
+	return useWhereStruct{use, whereArgs}.String()
+}
+
+type WhereArg struct {
+	Arg   string
+	Short string
+}
+
+func (w WhereArg) Len() int {
+	return len(w.Arg)
+}
+
+type useWhereStruct struct {
+	Use       string
+	WhereArgs []WhereArg
+}
+
+func (uw useWhereStruct) String() string {
+	use := uw.Use
+	if len(uw.WhereArgs) > 0 {
+		// Leave order of whereArgs as specified by the caller
+		use = use + "\n\nWhere:"
+		maxArgWidth := uw.whereArgMaxLen()
+		for _, where := range uw.WhereArgs {
+			use = use + fmt.Sprintf("\n  %-*s\t%s", maxArgWidth, where.Arg, where.Short)
+		}
+	}
+	return use
+}
+
+func (uw useWhereStruct) whereArgMaxLen() int {
+	widestWhereArg := slices.MaxFunc(uw.WhereArgs[:], func(a, b WhereArg) int {
+		return a.Len() - b.Len()
+	})
+	return widestWhereArg.Len()
+}

--- a/console/prompt.go
+++ b/console/prompt.go
@@ -6,15 +6,23 @@ import (
 	"github.com/manifoldco/promptui"
 )
 
-func GetUserInput(label string) (string, error) {
-	return GetUserInputWithValidation(label, nil)
+type UserInputOptionsStruct struct {
+	Label   string
+	Default string `default:""`
 }
 
-func GetUserInputWithValidation(label string, validate func(string) error) (string, error) {
+func GetUserInput(label string, value string) (string, error) {
+	return GetUserInputWithValidation(label, value, nil)
+}
+
+func GetUserInputWithValidation(label string, value string, validate func(string) error) (string, error) {
 	prompt := promptui.Prompt{
 		Label:       label,
 		HideEntered: true,
+		Default:     value,
+		AllowEdit:   true,
 		Validate:    validate,
+		Pointer:     promptui.DefaultCursor,
 	}
 
 	return prompt.Run()

--- a/gitspaces/space.go
+++ b/gitspaces/space.go
@@ -92,8 +92,11 @@ func (space *SpaceStruct) OpenVSCode() error {
 	return exec.Command(codeExecPath, space.codeWsFile).Start()
 }
 
-func (space *SpaceStruct) Rename() error {
-	return space.move("Rename")
+// Rename renames the space.
+// It takes a variadic parameter of type string, which represents the optional new name for the space.
+// If successful, it returns nil. Otherwise, it returns an error.
+func (space *SpaceStruct) Rename(arguments ...string) error {
+	return space.move("Rename", arguments...)
 }
 
 func (space *SpaceStruct) Sleep() (err error) {
@@ -149,9 +152,14 @@ func (space *SpaceStruct) deleteCodeWorkspaceFile() (err error) {
 	return nil
 }
 
-func (space *SpaceStruct) move(moveVerb string) error {
+func (space *SpaceStruct) move(moveVerb string, arguments ...string) error {
+	var newName string // pining for default args and/or a ternary operator :/
+	if len(arguments) > 0 {
+		newName = arguments[0]
+	}
 	name, err := console.GetUserInputWithValidation(
 		fmt.Sprintf("%s space as", moveVerb),
+		newName,
 		func(s string) error {
 			checkpath := filepath.Join(space.project.Path, s)
 			if strings.HasPrefix(s, ".") || helper.PathExists(checkpath) {


### PR DESCRIPTION
Add 'move' and 'mv' aliases to 'rename' cmd. Add WhereArgs to help for all commands that use them.